### PR TITLE
fix: support PI_CODING_AGENT_DIR session paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pi -e ./pi-token-usage/src/index.ts
 | Argument | Description |
 |----------|-------------|
 | `[days]` | Number — show sessions from the last N days |
-| `[path]` | Path to a `.jsonl` file or directory (default: `~/.pi/agent/sessions`) |
+| `[path]` | Path to a `.jsonl` file or directory (default: `~/.pi/agent/sessions`, or `$PI_CODING_AGENT_DIR/sessions` when set) |
 | `--format, -f` | Output format: `table` (default), `csv`, `json`, `markdown` (alias: `md`) |
 | `--save, -s` | Write output to file instead of stdout/TUI |
 
@@ -59,7 +59,7 @@ pi -e ./pi-token-usage/src/index.ts
 | `<days>` | Number (required) — delete sessions older than N days |
 | `--dry-run, -d` | Preview what would be deleted without actually deleting |
 | `--force, -f` | Skip confirmation prompt when deleting many files |
-| `--path, -p` | Path to a directory (default: `~/.pi/agent/sessions`) |
+| `--path, -p` | Path to a directory (default: `~/.pi/agent/sessions`, or `$PI_CODING_AGENT_DIR/sessions` when set) |
 
 ### Prune Behavior
 
@@ -106,7 +106,7 @@ bun test:coverage     # Run tests and show coverage stats
 
 ### Report Generation
 
-1. Scans `~/.pi/agent/sessions` (or given path) for `.jsonl` session files
+1. Scans `~/.pi/agent/sessions` (or `$PI_CODING_AGENT_DIR/sessions` when set, or a given path) for `.jsonl` session files
 2. Parses each file, extracting `assistant` messages with `usage` data
 3. Aggregates token counts and costs per model+provider
 4. Renders in the requested format

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,7 +39,15 @@ export function fmtDaysLabel(daysArg: number | null): string | null {
 // Argument parsing
 // ──────────────────────────────────────────────────────────────────────────────
 
-export const DEFAULT_SESSIONS_DIR = () => resolve(homedir(), ".pi", "agent", "sessions");
+export const DEFAULT_PI_CODING_AGENT_DIR = () => {
+  const configuredDir = process.env.PI_CODING_AGENT_DIR?.trim();
+  return configuredDir ? resolve(configuredDir) : resolve(homedir(), ".pi", "agent");
+};
+
+export const DEFAULT_SESSIONS_DIR = () => resolve(DEFAULT_PI_CODING_AGENT_DIR(), "sessions");
+
+export const DEFAULT_SESSIONS_DESC = () =>
+  process.env.PI_CODING_AGENT_DIR?.trim() ? DEFAULT_SESSIONS_DIR() : "~/.pi/agent/sessions";
 
 const VALID_FORMATS: OutputFormat[] = ["table", "csv", "json", "markdown"];
 
@@ -94,7 +102,7 @@ export function parseArgs(rawArgs: string, cwd: string): ParsedArgs {
 
   if (!targetPath) {
     targetPath = DEFAULT_SESSIONS_DIR();
-    targetDesc = "~/.pi/agent/sessions";
+    targetDesc = DEFAULT_SESSIONS_DESC();
   }
   if (!targetDesc) targetDesc = targetPath;
 

--- a/test/prune.test.ts
+++ b/test/prune.test.ts
@@ -5,6 +5,21 @@ import { tmpdir } from "node:os";
 import { parsePruneArgs, pruneSessions, formatPruneReport } from "../src/prune.js";
 
 describe("parsePruneArgs", () => {
+  let originalPiCodingAgentDir: string | undefined;
+
+  beforeEach(() => {
+    originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+    delete process.env.PI_CODING_AGENT_DIR;
+  });
+
+  afterEach(() => {
+    if (originalPiCodingAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+      return;
+    }
+    process.env.PI_CODING_AGENT_DIR = originalPiCodingAgentDir;
+  });
+
   test("throws error for empty input", () => {
     expect(() => parsePruneArgs("", "/cwd")).toThrow("Missing required argument: days");
   });
@@ -55,6 +70,14 @@ describe("parsePruneArgs", () => {
   test("uses default sessions directory when no path provided", () => {
     const result = parsePruneArgs("30", "/cwd");
     expect(result.targetPath).toContain(".pi");
+  });
+
+  test("uses PI_CODING_AGENT_DIR for default target path", () => {
+    process.env.PI_CODING_AGENT_DIR = "/custom/pi-agent";
+
+    const result = parsePruneArgs("30", "/cwd");
+
+    expect(result.targetPath).toBe("/custom/pi-agent/sessions");
   });
 
   test("throws error for missing days argument", () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { fmt, fmtUsd, csvQuote, parseArgs, DEFAULT_SESSIONS_DIR, fmtDaysSuffix, fmtDaysLabel } from "../src/utils.js";
 
 describe("fmt", () => {
@@ -48,6 +48,21 @@ describe("csvQuote", () => {
 });
 
 describe("parseArgs", () => {
+  let originalPiCodingAgentDir: string | undefined;
+
+  beforeEach(() => {
+    originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+    delete process.env.PI_CODING_AGENT_DIR;
+  });
+
+  afterEach(() => {
+    if (originalPiCodingAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+      return;
+    }
+    process.env.PI_CODING_AGENT_DIR = originalPiCodingAgentDir;
+  });
+
   test("returns defaults for empty input", () => {
     const result = parseArgs("", "/cwd");
     expect(result.daysArg).toBeNull();
@@ -55,6 +70,15 @@ describe("parseArgs", () => {
     expect(result.targetDesc).toBe("~/.pi/agent/sessions");
     expect(result.format).toBe("table");
     expect(result.savePath).toBeNull();
+  });
+
+  test("uses PI_CODING_AGENT_DIR for default target path", () => {
+    process.env.PI_CODING_AGENT_DIR = "/custom/pi-agent";
+
+    const result = parseArgs("", "/cwd");
+
+    expect(result.targetPath).toBe("/custom/pi-agent/sessions");
+    expect(result.targetDesc).toBe("/custom/pi-agent/sessions");
   });
 
   test("parses numeric arg as daysArg", () => {


### PR DESCRIPTION
## Summary
- respect `PI_CODING_AGENT_DIR` when deriving the default sessions directory
- show the env-based default path in command metadata when no explicit path is provided
- add regression tests and document the env-aware default path

## Testing
- `bun run validate`
- `bun test`

Closes #32

<sup>PR opened by gpt-5.5 high on pi</sup>
